### PR TITLE
Now emitting excludes on empty arrays, had been failing

### DIFF
--- a/test/fixtures/pdc/diabetes_hgba1c_value_map.js
+++ b/test/fixtures/pdc/diabetes_hgba1c_value_map.js
@@ -42,6 +42,11 @@ function map(patient) {
     function hasMatchingLabValue() {
         for (var i = 0; i < resultList.length; i++) {
             if (resultList[i].includesCodeFrom(targetLabCodes) && resultList[i].timeStamp() > start) {
+                // Emit excluded when resultList[] exists, but empty
+                if(resultList[i].values() === null || resultList[i].values === undefined || resultList[i].values.length === 0) {
+                    emit('excluded', 1);
+                    continue;
+                }
                 if (resultList[i].values()[0].units() !== null &&
                     resultList[i].values()[0].units().toLowerCase() === "%".toLowerCase()) {
                     if (resultList[i].values()[0].scalar() <= hgba1cLimit) {

--- a/test/fixtures/pdc/diabetes_ldl_map.js
+++ b/test/fixtures/pdc/diabetes_ldl_map.js
@@ -42,6 +42,11 @@ function map(patient) {
     function hasMatchingLabValue() {
         for (var i = 0; i < resultList.length; i++) {
             if (resultList[i].includesCodeFrom(targetLabCodes) && resultList[i].timeStamp() > start) {
+                // Emit excluded when resultList[] exists, but empty
+                if(resultList[i].values() === null || resultList[i].values === undefined || resultList[i].values.length === 0) {
+                    emit('excluded', 1);
+                    continue;
+                }
                 if (resultList[i].values()[0].units() !== null &&
                     resultList[i].values()[0].units().toLowerCase() === "mmol/L".toLowerCase()) {
                     if (resultList[i].values()[0].scalar() <= ldlLimit) {

--- a/test/fixtures/pdc/renal_digoxin_value_map.js
+++ b/test/fixtures/pdc/renal_digoxin_value_map.js
@@ -82,11 +82,17 @@ function map(patient) {
     function hasMatchingCreatinineValue() {
         for (var i = 0; i < resultList.length; i++) {
             if (resultList[i].includesCodeFrom(targetCreatinineCodes) &&
-                resultList[i].timeStamp() > start) {
-                if (resultList[i].values()[0].units() !== null &&
-                    resultList[i].values()[0].units().toLowerCase() === "umol/L".toLowerCase()) {
-                    if (resultList[i].values()[0].scalar() > creatinineLimit) {
-                        return true;
+              resultList[i].timeStamp() > start) {
+                if (resultList[i].includesCodeFrom(targetLabCodes) && resultList[i].timeStamp() > start) {
+                    // Emit excluded when resultList[] exists, but empty
+                    if(resultList[i].values() === null || resultList[i].values === undefined || resultList[i].values.length === 0) {
+                        emit('excluded', 1);
+                        continue;
+                    }
+                    if (resultList[i].values()[0].units() !== null &&
+                      resultList[i].values()[0].units().toLowerCase() === "umol/L".toLowerCase()) {
+                        if (resultList[i].values()[0].scalar() > creatinineLimit) {
+                            return true;
                     }
                 }
             }


### PR DESCRIPTION
Three queries had been failing on data that returned a numerator of 0.  The error was from using an empty array.  The changes emit excluded instead of failing.
